### PR TITLE
fix: mutable-buffer has no default export

### DIFF
--- a/src/escpos.js
+++ b/src/escpos.js
@@ -1,4 +1,4 @@
-var MutableBuffer = require('mutable-buffer'),
+var { MutableBuffer } = require('mutable-buffer'),
     CMD = require('./commands');
 
 class Escpos {


### PR DESCRIPTION
Mutable buffer package has no default export, it needs to be destructured or else the `Escpos` class won't work.